### PR TITLE
Fix query generation

### DIFF
--- a/utils/repositories.go
+++ b/utils/repositories.go
@@ -36,9 +36,9 @@ func Paginate(completeQuery string, pageIndex int, pageSize int) (query string, 
 	}
 
 	offset := pageSize * (pageIndex - 1)
-	replaceRegex := regexp.MustCompile("select .* from")
-	trimRegex := regexp.MustCompile("order by .*")
-	return fmt.Sprintf("%s offset %d limit %d", completeQuery, offset, pageSize), trimRegex.ReplaceAllString(replaceRegex.ReplaceAllString(completeQuery, "select count(*) from"), ""), nil
+	replaceRegex := regexp.MustCompile("select .* from ")
+	trimRegex := regexp.MustCompile(" order by .*")
+	return fmt.Sprintf("%s offset %d limit %d", completeQuery, offset, pageSize), trimRegex.ReplaceAllString(replaceRegex.ReplaceAllString(completeQuery, "select count(*) from "), ""), nil
 }
 
 func AppendWhereClause[T any](currentQuery string, columnName string, operand string, value T, isSet func(T) bool, positionalValues []any) (newQuery string, newPositional []any) {

--- a/utils/repositories.go
+++ b/utils/repositories.go
@@ -46,8 +46,13 @@ func AppendWhereClause[T any](currentQuery string, columnName string, operand st
 		return currentQuery, positionalValues
 	}
 
+	lastFrom := strings.LastIndex(currentQuery, " from ")
+	// this is to prevent subqueries from being included in the search
+	// otherwise, if the subquery already container the "where" clause, the actual query would just get "and" appended
+	finalQueryFrom := currentQuery[lastFrom:]
+
 	combiningWord := "where"
-	if strings.Contains(currentQuery, "where") {
+	if strings.Contains(finalQueryFrom, "where") {
 		combiningWord = "and"
 	}
 

--- a/utils/repositories_test.go
+++ b/utils/repositories_test.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"github.com/Geepr/game/mocks"
+	"testing"
+)
+
+func TestPaginate_CountQueryReturnsCorrect(t *testing.T) {
+	testData := []struct {
+		query      string
+		countQuery string
+	}{
+		{"select * from test_table order by a", "select count(*) from test_table"},
+		{"select * from test_table where test_column = 1 order by a", "select count(*) from test_table where test_column = 1"},
+		{"select a, b, c from test_table order by a", "select count(*) from test_table"},
+		{"select * from test_table where from_column = 5 order by a", "select count(*) from test_table where from_column = 5"},
+		{"select * from from_test_table order by a", "select count(*) from from_test_table"},
+		{"select a, b, (select * from another_table where a = $1) from test_table where b = $2 order by a", "select count(*) from test_table where b = $2"},
+	}
+
+	for _, data := range testData {
+		currentTestData := data
+		t.Run(currentTestData.query, func(t *testing.T) {
+			_, countQuery, err := Paginate(currentTestData.query, 1, 1)
+			mocks.AssertEquals(t, err, nil)
+			mocks.AssertEquals(t, currentTestData.countQuery, countQuery)
+		})
+	}
+}

--- a/utils/repositories_test.go
+++ b/utils/repositories_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/Geepr/game/mocks"
+	"strings"
 	"testing"
 )
 
@@ -16,14 +17,35 @@ func TestPaginate_CountQueryReturnsCorrect(t *testing.T) {
 		{"select * from test_table where from_column = 5 order by a", "select count(*) from test_table where from_column = 5"},
 		{"select * from from_test_table order by a", "select count(*) from from_test_table"},
 		{"select a, b, (select * from another_table where a = $1) from test_table where b = $2 order by a", "select count(*) from test_table where b = $2"},
+		{"select a, b, (select * from another_table where a = $1 order by u) from test_table where b = $2 order by a", "select count(*) from test_table where b = $2"},
 	}
 
 	for _, data := range testData {
 		currentTestData := data
 		t.Run(currentTestData.query, func(t *testing.T) {
-			_, countQuery, err := Paginate(currentTestData.query, 1, 1)
+			resultQuery, countQuery, err := Paginate(currentTestData.query, 1, 1)
 			mocks.AssertEquals(t, err, nil)
 			mocks.AssertEquals(t, currentTestData.countQuery, countQuery)
+			mocks.AssertEquals(t, strings.HasPrefix(resultQuery, currentTestData.query), true)
+		})
+	}
+}
+
+func TestAppendWhereClause_AppendedCorrectly(t *testing.T) {
+	testData := []struct {
+		query    string
+		appended string
+	}{
+		{"select * from test_table", "select * from test_table where a = $1"},
+		{"select a, b, c from test_table", "select a, b, c from test_table where a = $1"},
+		{"select a, b, (select * from another_table where a = u) from test_table", "select a, b, (select * from another_table where a = u) from test_table where a = $1"},
+	}
+
+	for _, data := range testData {
+		currentData := data
+		t.Run(currentData.query, func(t *testing.T) {
+			resultQuery, _ := AppendWhereClause(currentData.query, "a", "=", "b", func(s string) bool { return true }, []any{})
+			mocks.AssertEquals(t, resultQuery, currentData.appended)
 		})
 	}
 }


### PR DESCRIPTION
There are 2 fixes here:
- 84d2bd94cb6e88c48c1869c2c3f7ca4ceb686133 fixes a minor bug in which if the table name started with `from`, then it would be incorrectly treated as the `from` keyword by the count query
- f32270c45a703e9a077a9e9b32ce6ec276151f9f fixes a much bigger issue, in which if a subquery was used in `select` part of the query, and that subquery happened to contain `where` clause, then instead of appending `where` to the final query, the code would just append `and` and assume this `where` in subquery was enough

Closes #27 